### PR TITLE
Fix query search in pRolocVis

### DIFF
--- a/R/pRolocVis.R
+++ b/R/pRolocVis.R
@@ -357,7 +357,7 @@ pRolocVis <- function(object) {
                 
                 observe({ 
                     .prot$text <- .obsProtText(.dI(), .prot$text, input$saveText, 
-                            isolate(input$sRTextInput), input$search)
+                            isolate(input$sRTextInput), input$search, names=TRUE)
                 })
                 
                 observe({


### PR DESCRIPTION
Submit selection button from the query function was not sending the correct indices to generate features of interest